### PR TITLE
Production readiness: Windows Service/systemd hosting, OpenTelemetry hardening, release tooling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*.*.*"]
+
+jobs:
+  build-test-and-release:
+    name: Build, test, and publish release artifacts
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Restore
+        run: dotnet restore Arbor.DevPackages.slnx
+
+      - name: Build
+        run: dotnet build Arbor.DevPackages.slnx --no-restore --configuration Release
+
+      - name: Test
+        run: dotnet test Arbor.DevPackages.slnx --no-build --configuration Release --filter "Category!=SystemTest_Online" --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Threshold=80
+
+      - name: Publish release artifacts
+        shell: pwsh
+        run: ./scripts/publish.ps1 -Version "${{ github.ref_name }}"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            artifacts/release/*.zip artifacts/release/*.sha256 artifacts/release/manifest.json \
+            --title "${{ github.ref_name }}" \
+            --generate-notes

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,12 @@
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+
+    <!-- Production hosting (Windows Service / systemd) -->
+    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Systemd" Version="10.0.0" />
 
     <!-- Testing -->
     <PackageVersion Include="Arbor.Aesculus.NCrunch" Version="3.9.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,9 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
 
     <!-- Storage -->
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.7" />
+    <!-- Pinned to 10.0.11 (not floating) to pull in SQLitePCLRaw >= 2.1.12, which fixes
+         GHSA-2m69-gcr7-jv3q (SQLitePCLRaw.lib.e_sqlite3 <= 2.1.11). -->
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.11" />
 
     <!-- Aspire (Aspire.Hosting.AppHost is auto-referenced by Aspire.AppHost.Sdk) -->
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.5.0" />

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A local NuGet package server for excellent local package management and offline developer workflows.
 
-> **Status:** Pre-implementation — see [`docs/analysis.md`](docs/analysis.md) for the full analysis and [`docs/plan.md`](docs/plan.md) for the iterative implementation plan.
+> **Status:** All planned iterations (0–13) implemented — service index, flat-container, registration, search, stats, proxy, push, and HTTPS support are in place. See [`docs/analysis.md`](docs/analysis.md) for the design analysis and [`docs/plan.md`](docs/plan.md) for the iterative implementation plan.
 
 ## Goals
 
@@ -26,7 +26,7 @@ A local NuGet package server for excellent local package management and offline 
 
 | Document | Purpose |
 |---|---|
-| [`docs/analysis.md`](docs/analysis.md) | Pre-implementation analysis: pros/cons, trade-offs, design decisions, resolved open questions |
+| [`docs/analysis.md`](docs/analysis.md) | Design analysis: pros/cons, trade-offs, design decisions, resolved open questions |
 | [`docs/plan.md`](docs/plan.md) | Iterative TDD implementation plan — from scaffold to HTTPS |
 
 ## Inspiration

--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ HTTPS is an opt-in configuration option. HTTP on port 5000 is the default for lo
 Logging, tracing, and metrics are wired up in `Arbor.DevPackages.ServiceDefaults` for every
 environment (not just under Aspire):
 
-- **Logging**: structured logs flow through the standard `ILogger` pipeline, exported via OTel
-  and always also written to the console.
+- **Logging**: structured logs flow through the standard `ILogger` pipeline and are always
+  written to the console; they are also exported via OTel once an OTLP endpoint is configured
+  (see below).
 - **Tracing**: ASP.NET Core and outgoing `HttpClient` spans.
 - **Metrics**: ASP.NET Core, `HttpClient`, and .NET runtime metrics (GC, JIT, thread pool,
   exceptions) via `OpenTelemetry.Instrumentation.Runtime`.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,57 @@ HTTPS is an opt-in configuration option. HTTP on port 5000 is the default for lo
 
 > **Security note:** The minimum TLS version enforced by the server is TLS 1.2; TLS 1.3 is preferred when both sides support it.
 
+## Observability (OpenTelemetry)
+
+Logging, tracing, and metrics are wired up in `Arbor.DevPackages.ServiceDefaults` for every
+environment (not just under Aspire):
+
+- **Logging**: structured logs flow through the standard `ILogger` pipeline, exported via OTel
+  and always also written to the console.
+- **Tracing**: ASP.NET Core and outgoing `HttpClient` spans.
+- **Metrics**: ASP.NET Core, `HttpClient`, and .NET runtime metrics (GC, JIT, thread pool,
+  exceptions) via `OpenTelemetry.Instrumentation.Runtime`.
+- Every signal carries `service.name` / `service.version` (from the assembly's informational
+  version, which embeds the git commit) / `service.instance.id` and a `deployment.environment`
+  resource attribute.
+
+Export to an OTLP collector (Jaeger, Grafana, Aspire dashboard, etc.) by setting
+`OTEL_EXPORTER_OTLP_ENDPOINT`; without it, only console logging is active — no traces or
+metrics are exported. Point the collector at a private network segment, never a public endpoint.
+
+## Production deployment
+
+### Framework-independent (self-contained) release artifacts
+
+```shell
+pwsh ./scripts/publish.ps1
+```
+
+Publishes single-file, self-contained builds of `Arbor.DevPackages.Server` for `win-x64`,
+`linux-x64`, `linux-arm64`, `osx-x64`, and `osx-arm64` (override with `-RuntimeIdentifiers`) into
+`artifacts/release/`. Each platform gets a zipped archive, a `.sha256` checksum file, and the set
+is summarized in `manifest.json`. "Self-contained" means the target machine does **not** need the
+.NET runtime installed.
+
+### Run as a Windows Service
+
+```powershell
+pwsh ./scripts/publish.ps1 -RuntimeIdentifiers win-x64
+# Extract artifacts/release/Arbor.DevPackages.Server-<version>-win-x64.zip, then, elevated:
+pwsh ./scripts/install-windows-service.ps1 -ExecutablePath C:\Apps\ArborDevPackages\Arbor.DevPackages.Server.exe
+Start-Service -Name Arbor.DevPackages
+```
+
+`Program.cs` calls `UseWindowsService()`, which is a no-op everywhere except when the process is
+actually started by the Windows Service Control Manager — the same published exe runs equally
+well from the console. Use `scripts/uninstall-windows-service.ps1` to remove the service.
+
+### Run under systemd (Linux)
+
+`Program.cs` also calls `UseSystemd()`. Publish for `linux-x64`, extract the archive, and install
+the example unit at [`scripts/arbor-devpackages.service`](scripts/arbor-devpackages.service) — see
+the comments in that file for the full setup.
+
 ## License
 
 MIT — see [LICENSE](LICENSE).

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -27,6 +27,20 @@ Arbor.DevPackages uses the following third-party packages. Each package retains 
 - **Project:** https://github.com/dotnet/aspire
 - **Used in:** `Arbor.DevPackages.ServiceDefaults`
 
+### Microsoft.Extensions.Hosting.WindowsServices
+
+- **Version:** 10.0.0
+- **License:** MIT
+- **Project:** https://github.com/dotnet/runtime
+- **Used in:** `Arbor.DevPackages.Server` (run as a Windows Service via `UseWindowsService`)
+
+### Microsoft.Extensions.Hosting.Systemd
+
+- **Version:** 10.0.0
+- **License:** MIT
+- **Project:** https://github.com/dotnet/runtime
+- **Used in:** `Arbor.DevPackages.Server` (run under systemd via `UseSystemd`)
+
 ### OpenTelemetry.Exporter.OpenTelemetryProtocol
 
 - **Version:** 1.15.3
@@ -54,6 +68,13 @@ Arbor.DevPackages uses the following third-party packages. Each package retains 
 - **License:** Apache 2.0
 - **Project:** https://github.com/open-telemetry/opentelemetry-dotnet-contrib
 - **Used in:** `Arbor.DevPackages.ServiceDefaults`
+
+### OpenTelemetry.Instrumentation.Runtime
+
+- **Version:** 1.15.1
+- **License:** Apache 2.0
+- **Project:** https://github.com/open-telemetry/opentelemetry-dotnet-contrib
+- **Used in:** `Arbor.DevPackages.ServiceDefaults` (GC, JIT, thread pool, and exception metrics)
 
 ---
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -8,7 +8,7 @@ Arbor.DevPackages uses the following third-party packages. Each package retains 
 
 ### Microsoft.Data.Sqlite
 
-- **Version:** 10.0.7
+- **Version:** 10.0.11
 - **License:** MIT
 - **Project:** https://github.com/dotnet/efcore
 - **Used in:** `Arbor.DevPackages.Storage.Sqlite`
@@ -82,14 +82,14 @@ Arbor.DevPackages uses the following third-party packages. Each package retains 
 
 ### Aspire.AppHost.Sdk (SDK)
 
-- **Version:** 13.2.4
+- **Version:** 13.4.6
 - **License:** MIT
 - **Project:** https://github.com/dotnet/aspire
 - **Used in:** `Arbor.DevPackages.AppHost` (as MSBuild SDK)
 
 ### Aspire.Hosting.AppHost (auto-referenced by Aspire.AppHost.Sdk)
 
-- **Version:** 13.2.4
+- **Version:** 13.4.6
 - **License:** MIT
 - **Project:** https://github.com/dotnet/aspire
 - **Used in:** `Arbor.DevPackages.AppHost`

--- a/docs/security-review.md
+++ b/docs/security-review.md
@@ -74,7 +74,11 @@ Address any reported vulnerabilities before merging. Do not disable or skip this
 
 ## Initial Dependency Review
 
-No production dependencies have been added yet (pre-implementation phase). This section will be updated with the first dependency audit result after the solution is initialized.
+Production dependencies are tracked in [`THIRD_PARTY_NOTICES.md`](../THIRD_PARTY_NOTICES.md), all
+MIT or Apache 2.0 licensed. `dotnet list package --vulnerable --include-transitive` runs on every
+CI build (see `.github/workflows/ci.yml`); NuGet audit warnings are treated as build errors
+(`TreatWarningsAsErrors`), so a newly-disclosed advisory in any dependency — direct or transitive
+— fails the build until the affected package is bumped or pinned to a patched version.
 
 ## Guidelines for Future PRs
 

--- a/docs/security-review.md
+++ b/docs/security-review.md
@@ -59,7 +59,18 @@ Address any reported vulnerabilities before merging. Do not disable or skip this
 - Set `persist-credentials: false` on all `actions/checkout` steps.
 - Keep job/workflow permissions minimal (use `permissions:` key at workflow or job level).
 - Upload only required artifacts; set `retention-days: 14` on CI artifacts.
-- Provide SHA-256 checksums for release binaries.
+- Provide SHA-256 checksums for release binaries — `scripts/publish.ps1` writes a `.sha256` file
+  alongside every published archive, and `.github/workflows/release.yml` uploads both.
+
+### 7. Production hosting
+
+- Run the Windows Service / systemd service under a dedicated, least-privilege account — never
+  `LocalSystem` or `root` — scoped to the package store and configuration directories it needs.
+- `PublishSingleFile` self-contained artifacts bundle the .NET runtime; keep the deployed host
+  patched at the OS level and re-publish on every .NET servicing release, since there is no
+  separately-updatable shared runtime to patch.
+- Prefer the OTLP exporter (`OTEL_EXPORTER_OTLP_ENDPOINT`) pointed at a collector on a private
+  network segment; never expose the collector endpoint publicly.
 
 ## Initial Dependency Review
 

--- a/scripts/arbor-devpackages.service
+++ b/scripts/arbor-devpackages.service
@@ -1,0 +1,30 @@
+# systemd unit for Arbor.DevPackages.Server on Linux.
+#
+# Setup:
+#   1. ./scripts/publish.ps1 -RuntimeIdentifiers linux-x64
+#   2. Extract artifacts/release/Arbor.DevPackages.Server-<version>-linux-x64.zip to
+#      /opt/arbor-devpackages, then: chmod +x /opt/arbor-devpackages/Arbor.DevPackages.Server
+#   3. sudo cp scripts/arbor-devpackages.service /etc/systemd/system/
+#   4. sudo systemctl daemon-reload
+#   5. sudo systemctl enable --now arbor-devpackages
+#
+# Program.cs calls builder.Host.UseSystemd(), so the service picks up sd_notify
+# (start/stop/watchdog) signals automatically when run under systemd with Type=notify.
+
+[Unit]
+Description=Arbor.DevPackages NuGet Server
+After=network.target
+
+[Service]
+Type=notify
+WorkingDirectory=/opt/arbor-devpackages
+ExecStart=/opt/arbor-devpackages/Arbor.DevPackages.Server
+Restart=on-failure
+RestartSec=5
+User=arbor-devpackages
+Environment=DOTNET_ENVIRONMENT=Production
+# Environment=OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+# Environment=PackageStorePath=/var/lib/arbor-devpackages/store
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/install-windows-service.ps1
+++ b/scripts/install-windows-service.ps1
@@ -1,0 +1,63 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Registers a published, self-contained Arbor.DevPackages.Server build as a Windows Service.
+
+.DESCRIPTION
+    Windows only. Requires an elevated (Administrator) PowerShell session.
+    Run scripts/publish.ps1 -RuntimeIdentifiers win-x64 first, then point this script at the
+    extracted publish output (or the .zip's extracted contents).
+
+.PARAMETER ExecutablePath
+    Full path to Arbor.DevPackages.Server.exe from a self-contained win-x64 publish output.
+
+.PARAMETER ServiceName
+    Windows Service name. Defaults to "Arbor.DevPackages".
+
+.PARAMETER DisplayName
+    Windows Service display name. Defaults to "Arbor.DevPackages NuGet Server".
+
+.PARAMETER StartupType
+    Service startup type. Defaults to Automatic.
+
+.EXAMPLE
+    ./scripts/install-windows-service.ps1 -ExecutablePath C:\Apps\ArborDevPackages\Arbor.DevPackages.Server.exe
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ExecutablePath,
+
+    [string]$ServiceName = "Arbor.DevPackages",
+
+    [string]$DisplayName = "Arbor.DevPackages NuGet Server",
+
+    [ValidateSet("Automatic", "Manual", "Disabled")]
+    [string]$StartupType = "Automatic"
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $IsWindows) {
+    throw "install-windows-service.ps1 registers a Windows Service and must be run on Windows."
+}
+
+$currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+if (-not $currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    throw "Run this script from an elevated (Administrator) PowerShell session."
+}
+
+$ExecutablePath = Resolve-Path $ExecutablePath -ErrorAction Stop
+
+if (Get-Service -Name $ServiceName -ErrorAction SilentlyContinue) {
+    throw "A service named '$ServiceName' already exists. Run uninstall-windows-service.ps1 first if you want to replace it."
+}
+
+New-Service `
+    -Name $ServiceName `
+    -BinaryPathName "`"$ExecutablePath`"" `
+    -DisplayName $DisplayName `
+    -Description "Local NuGet v3 package server (read-through proxy, offline cache)." `
+    -StartupType $StartupType
+
+Write-Host "Service '$ServiceName' installed. Start it with: Start-Service -Name '$ServiceName'" -ForegroundColor Green

--- a/scripts/install-windows-service.ps1
+++ b/scripts/install-windows-service.ps1
@@ -53,9 +53,17 @@ if (Get-Service -Name $ServiceName -ErrorAction SilentlyContinue) {
     throw "A service named '$ServiceName' already exists. Run uninstall-windows-service.ps1 first if you want to replace it."
 }
 
+# The app must register itself with the SCM under the exact name it was installed as (the SCM
+# dispatches control requests by that name), so pass it through as a command-line configuration
+# override read by Program.cs (WindowsService:ServiceName) whenever it differs from the default.
+$binaryPathName = "`"$ExecutablePath`""
+if ($ServiceName -ne "Arbor.DevPackages") {
+    $binaryPathName += " --WindowsService:ServiceName `"$ServiceName`""
+}
+
 New-Service `
     -Name $ServiceName `
-    -BinaryPathName "`"$ExecutablePath`"" `
+    -BinaryPathName $binaryPathName `
     -DisplayName $DisplayName `
     -Description "Local NuGet v3 package server (read-through proxy, offline cache)." `
     -StartupType $StartupType

--- a/scripts/publish.ps1
+++ b/scripts/publish.ps1
@@ -1,0 +1,120 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Builds framework-independent (self-contained), single-file release artifacts
+    for Arbor.DevPackages.Server, ready for production deployment (including as a
+    Windows Service or a Linux systemd service).
+
+.DESCRIPTION
+    For each requested runtime identifier, runs `dotnet publish` with:
+      - --self-contained true      (no .NET runtime required on the target machine)
+      - -p:PublishSingleFile=true  (one executable per platform)
+      - -p:PublishTrimmed=false    (ASP.NET Core + reflection-based NuGet libraries
+                                    are not trim-safe; trimming is intentionally left off)
+    Each publish output is zipped and a SHA-256 checksum file is written alongside it,
+    per the release-integrity practice documented in docs/security-review.md.
+
+.PARAMETER Configuration
+    Build configuration. Defaults to Release.
+
+.PARAMETER RuntimeIdentifiers
+    One or more .NET runtime identifiers to publish for.
+    Defaults to win-x64, linux-x64, linux-arm64, osx-x64, osx-arm64.
+
+.PARAMETER Version
+    Version to stamp into the assemblies and artifact file names.
+    Defaults to `git describe --tags --always`, falling back to "0.0.0-local".
+
+.PARAMETER OutputRoot
+    Directory the versioned, zipped artifacts are written to. Defaults to "artifacts/release".
+
+.EXAMPLE
+    ./scripts/publish.ps1
+
+.EXAMPLE
+    ./scripts/publish.ps1 -RuntimeIdentifiers win-x64 -Version 1.2.3
+#>
+[CmdletBinding()]
+param(
+    [string]$Configuration = "Release",
+
+    [string[]]$RuntimeIdentifiers = @("win-x64", "linux-x64", "linux-arm64", "osx-x64", "osx-arm64"),
+
+    [string]$Version,
+
+    [string]$OutputRoot = "artifacts/release"
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+$projectPath = Join-Path $repoRoot "src/Arbor.DevPackages.Server/Arbor.DevPackages.Server.csproj"
+
+if (-not $Version) {
+    $Version = (git -C $repoRoot describe --tags --always 2>$null)
+    if (-not $Version) {
+        $Version = "0.0.0-local"
+    }
+}
+$Version = $Version.TrimStart("v")
+
+$outputRootPath = Join-Path $repoRoot $OutputRoot
+New-Item -ItemType Directory -Force -Path $outputRootPath | Out-Null
+
+Write-Host "Publishing Arbor.DevPackages.Server $Version ($Configuration) for: $($RuntimeIdentifiers -join ', ')" -ForegroundColor Cyan
+
+$artifacts = @()
+
+foreach ($rid in $RuntimeIdentifiers) {
+    $publishDir = Join-Path $outputRootPath "publish/$rid"
+    if (Test-Path $publishDir) {
+        Remove-Item -Recurse -Force $publishDir
+    }
+
+    Write-Host "==> Publishing $rid" -ForegroundColor Yellow
+
+    dotnet publish $projectPath `
+        --configuration $Configuration `
+        --runtime $rid `
+        --self-contained true `
+        --output $publishDir `
+        -p:Version=$Version `
+        -p:PublishSingleFile=true `
+        -p:PublishTrimmed=false `
+        -p:IncludeNativeLibrariesForSelfExtract=true `
+        -p:EnableCompressionInSingleFile=true
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "dotnet publish failed for runtime '$rid' with exit code $LASTEXITCODE."
+    }
+
+    $archiveName = "Arbor.DevPackages.Server-$Version-$rid.zip"
+    $archivePath = Join-Path $outputRootPath $archiveName
+    if (Test-Path $archivePath) {
+        Remove-Item -Force $archivePath
+    }
+
+    Compress-Archive -Path (Join-Path $publishDir "*") -DestinationPath $archivePath
+
+    $hash = (Get-FileHash -Path $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+    "$hash  $archiveName" | Out-File -FilePath "$archivePath.sha256" -Encoding ascii -NoNewline
+
+    Write-Host "    $archiveName" -ForegroundColor Green
+    Write-Host "    sha256: $hash"
+
+    $artifacts += [pscustomobject]@{
+        Runtime  = $rid
+        Archive  = $archiveName
+        Sha256   = $hash
+    }
+}
+
+$manifestPath = Join-Path $outputRootPath "manifest.json"
+[pscustomobject]@{
+    Version   = $Version
+    BuiltAtUtc = (Get-Date).ToUniversalTime().ToString("O")
+    Artifacts = $artifacts
+} | ConvertTo-Json -Depth 4 | Out-File -FilePath $manifestPath -Encoding utf8
+
+Write-Host ""
+Write-Host "Done. Artifacts written to $outputRootPath" -ForegroundColor Cyan

--- a/scripts/uninstall-windows-service.ps1
+++ b/scripts/uninstall-windows-service.ps1
@@ -1,0 +1,50 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Stops and removes the Arbor.DevPackages.Server Windows Service.
+
+.DESCRIPTION
+    Windows only. Requires an elevated (Administrator) PowerShell session.
+
+.PARAMETER ServiceName
+    Windows Service name. Defaults to "Arbor.DevPackages".
+
+.EXAMPLE
+    ./scripts/uninstall-windows-service.ps1
+#>
+[CmdletBinding()]
+param(
+    [string]$ServiceName = "Arbor.DevPackages"
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $IsWindows) {
+    throw "uninstall-windows-service.ps1 removes a Windows Service and must be run on Windows."
+}
+
+$currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+if (-not $currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    throw "Run this script from an elevated (Administrator) PowerShell session."
+}
+
+$service = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
+if (-not $service) {
+    Write-Host "No service named '$ServiceName' is registered; nothing to do." -ForegroundColor Yellow
+    return
+}
+
+if ($service.Status -ne "Stopped") {
+    Stop-Service -Name $ServiceName -Force
+    $service.WaitForStatus("Stopped", [TimeSpan]::FromSeconds(30))
+}
+
+# Remove-Service was added in PowerShell 6+; sc.exe is used as a fallback for Windows PowerShell 5.1.
+if (Get-Command Remove-Service -ErrorAction SilentlyContinue) {
+    Remove-Service -Name $ServiceName
+}
+else {
+    sc.exe delete $ServiceName | Out-Null
+}
+
+Write-Host "Service '$ServiceName' removed." -ForegroundColor Green

--- a/src/Arbor.DevPackages.AppHost/Arbor.DevPackages.AppHost.csproj
+++ b/src/Arbor.DevPackages.AppHost/Arbor.DevPackages.AppHost.csproj
@@ -1,4 +1,6 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.2.4">
+<!-- 13.4.6, not floating: pulls StreamJsonRpc >= 2.25.29, which brings MessagePack >= 2.5.302,
+     fixing GHSA-hv8m-jj95-wg3x and related advisories in MessagePack < 2.5.301. -->
+<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>

--- a/src/Arbor.DevPackages.Server/Arbor.DevPackages.Server.csproj
+++ b/src/Arbor.DevPackages.Server/Arbor.DevPackages.Server.csproj
@@ -10,6 +10,8 @@
   <ItemGroup>
     <PackageReference Include="NuGet.Packaging" />
     <PackageReference Include="NuGet.Versioning" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" />
     <ProjectReference Include="..\Arbor.DevPackages.Core\Arbor.DevPackages.Core.csproj" />
     <ProjectReference Include="..\Arbor.DevPackages.ServiceDefaults\Arbor.DevPackages.ServiceDefaults.csproj" />
   </ItemGroup>

--- a/src/Arbor.DevPackages.Server/Program.cs
+++ b/src/Arbor.DevPackages.Server/Program.cs
@@ -26,7 +26,11 @@ var builder = WebApplication.CreateBuilder(new WebApplicationOptions
 // Both calls are context-aware no-ops unless the process is actually running as a Windows
 // Service or under systemd (detected via WindowsServiceHelpers/SystemdHelpers), so it is safe
 // to call them unconditionally for every hosting environment, including tests.
-builder.Host.UseWindowsService(options => options.ServiceName = "Arbor.DevPackages");
+// The name must match the name the service was registered under (see
+// scripts/install-windows-service.ps1 -ServiceName), since the SCM dispatches control
+// requests by that name; it is configurable here for the same reason.
+var windowsServiceName = builder.Configuration["WindowsService:ServiceName"] ?? "Arbor.DevPackages";
+builder.Host.UseWindowsService(options => options.ServiceName = windowsServiceName);
 builder.Host.UseSystemd();
 
 // Give in-flight requests time to complete before the service/process stops.

--- a/src/Arbor.DevPackages.Server/Program.cs
+++ b/src/Arbor.DevPackages.Server/Program.cs
@@ -12,8 +12,25 @@ using Arbor.DevPackages.Server.ServiceIndex;
 using Arbor.DevPackages.Server.StartPage;
 using Arbor.DevPackages.Server.Stats;
 using Arbor.DevPackages.ServiceDefaults;
+using Microsoft.Extensions.Hosting.WindowsServices;
 
-var builder = WebApplication.CreateBuilder(args);
+// The Windows Service Control Manager starts services with the working directory set to
+// %SystemRoot%\System32, so the content root must be pinned to the published exe's directory
+// when running as a Windows Service; otherwise appsettings.json would not be found.
+var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+{
+    Args = args,
+    ContentRootPath = WindowsServiceHelpers.IsWindowsService() ? AppContext.BaseDirectory : null
+});
+
+// Both calls are context-aware no-ops unless the process is actually running as a Windows
+// Service or under systemd (detected via WindowsServiceHelpers/SystemdHelpers), so it is safe
+// to call them unconditionally for every hosting environment, including tests.
+builder.Host.UseWindowsService(options => options.ServiceName = "Arbor.DevPackages");
+builder.Host.UseSystemd();
+
+// Give in-flight requests time to complete before the service/process stops.
+builder.Services.Configure<HostOptions>(options => options.ShutdownTimeout = TimeSpan.FromSeconds(30));
 
 // Enforce minimum TLS 1.2 and prefer TLS 1.3 for all HTTPS endpoints.
 builder.WebHost.ConfigureKestrel(options =>

--- a/src/Arbor.DevPackages.ServiceDefaults/Arbor.DevPackages.ServiceDefaults.csproj
+++ b/src/Arbor.DevPackages.ServiceDefaults/Arbor.DevPackages.ServiceDefaults.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
   </ItemGroup>
 </Project>

--- a/src/Arbor.DevPackages.ServiceDefaults/Extensions.cs
+++ b/src/Arbor.DevPackages.ServiceDefaults/Extensions.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.DependencyInjection;
@@ -6,6 +7,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
 namespace Arbor.DevPackages.ServiceDefaults;
@@ -33,11 +35,20 @@ public static class Extensions
             logging.IncludeScopes = true;
         });
 
+        var serviceVersion = Assembly.GetEntryAssembly()
+            ?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion
+            ?? "unknown";
+
         builder.Services.AddOpenTelemetry()
+            .ConfigureResource(resource => resource
+                .AddService(builder.Environment.ApplicationName, serviceVersion: serviceVersion, serviceInstanceId: Environment.MachineName)
+                .AddAttributes([new KeyValuePair<string, object>("deployment.environment", builder.Environment.EnvironmentName)]))
             .WithMetrics(metrics =>
             {
                 metrics.AddAspNetCoreInstrumentation()
-                    .AddHttpClientInstrumentation();
+                    .AddHttpClientInstrumentation()
+                    .AddRuntimeInstrumentation();
             })
             .WithTracing(tracing =>
             {


### PR DESCRIPTION
Started as a README status-banner fix and grew into a production-readiness pass, per follow-up request in-thread. Summary of what's in this PR:

## Hosting
- Run as a **Windows Service** (`UseWindowsService`) or under **systemd** (`UseSystemd`) — both are no-ops everywhere else, so `dotnet run`/tests are unaffected.
- Fixed the classic Windows Service content-root gotcha (SCM starts services with cwd `System32`).
- Windows Service name is configurable (`WindowsService:ServiceName`) so a custom `-ServiceName` in the install script stays in sync with what the app registers with the SCM.
- Bounded graceful-shutdown timeout.

## Observability (OpenTelemetry)
- OTel resource now carries `service.name`/`version`/`instance.id` and `deployment.environment`.
- Added `.NET` runtime metrics (GC/JIT/thread pool/exceptions) alongside existing ASP.NET Core + HttpClient tracing/metrics and OTel-piped logging.

## Release tooling
- `scripts/publish.ps1` — self-contained, single-file, framework-independent publish per RID with SHA-256 checksums + manifest.
- `scripts/install-windows-service.ps1` / `uninstall-windows-service.ps1`, `scripts/arbor-devpackages.service` (systemd unit example).
- `.github/workflows/release.yml` — tag-triggered build/test/publish/release.

## Dependency fix (CI)
- Bumped `Microsoft.Data.Sqlite` → 10.0.11 and `Aspire.AppHost.Sdk`/`Aspire.Hosting.AppHost` → 13.4.6 to clear NuGet audit failures from newly-disclosed advisories in transitive packages (`SQLitePCLRaw.lib.e_sqlite3`, `MessagePack`) — this was blocking restore on `main` too, unrelated to the rest of the diff.

## Docs
- README: status banner, Observability and Production deployment sections.
- `THIRD_PARTY_NOTICES.md`, `docs/security-review.md` updated accordingly.